### PR TITLE
Fix /data/ paths in documentation

### DIFF
--- a/_posts/2023-05-03-cais-cluster-documentation.md
+++ b/_posts/2023-05-03-cais-cluster-documentation.md
@@ -118,7 +118,7 @@ sleep 5
 
 ## Sharing files and folders with other users
 
-For security measures, if you make your directory readable or executable by other users you will be locked out from `ssh`'ing into the cluster. This prevents other users from manipulating your ssh keys and such.  If you do wish to share we've made the directories `/public_models`, `/private_models` and `/datasets`. Useable by everyone and you can share files and folders there.
+For security measures, if you make your directory readable or executable by other users you will be locked out from `ssh`'ing into the cluster. This prevents other users from manipulating your ssh keys and such.  If you do wish to share we've made the directories `/data/public_models`, `/data/private_models` and `/data/datasets`. Useable by everyone and you can share files and folders there.
 
 ## How to request a shared folder
 


### PR DESCRIPTION
The documentation says `/public_models` but the actual path is `/data/public_models`, same for the other paths. This is a minor point but would be nice to fix.